### PR TITLE
[docs] Add infos for Windows agent installation

### DIFF
--- a/docs/usage/openbas-agent.md
+++ b/docs/usage/openbas-agent.md
@@ -33,7 +33,7 @@ MacOS
 
 Windows
 
-  - Requirement → powershell 7 or higher, admin user, access to the openbas instance used
+  - Requirement → Powershell "run as administrator", access to the openbas instance used. If installation failed, try with Powershell 7 or higher.
   - Compatibility → All major Windows versions
   - Installation → Create a service with name openbas-agent ("Install Windows Agent")
   - Verification command line → `Get-Service -Name "OBASAgentService"`

--- a/docs/usage/openbas-agent.md
+++ b/docs/usage/openbas-agent.md
@@ -33,7 +33,7 @@ MacOS
 
 Windows
 
-  - Requirement → Powershell "run as administrator", access to the openbas instance used. If installation failed, try with Powershell 7 or higher.
+  - Requirement → Powershell "run as administrator", and ensure access to the OpenBAS instance being used. If the installation fails, try using PowerShell 7 or higher.
   - Compatibility → All major Windows versions
   - Installation → Create a service with name openbas-agent ("Install Windows Agent")
   - Verification command line → `Get-Service -Name "OBASAgentService"`


### PR DESCRIPTION
Installation with Powershell < 7 can or can not work (different github issues created with different errors : https://github.com/OpenBAS-Platform/openbas/issues/1151, https://github.com/OpenBAS-Platform/openbas/issues/1496 ). I allow now to try to install the agent with any Powershell and inform the user to install the agent with Powershell 7 if any error is encountered.