### PR TITLE
[docs] add emphasis on configuring rabbitmq postgres minio (#89)

### DIFF
--- a/docs/deployment/installation.md
+++ b/docs/deployment/installation.md
@@ -209,6 +209,8 @@ To connect to Caldera, you need to use one of the users defined in your `caldera
 OpenBAS will use the red user.
 
 ## Manual installation
+This section provides instructions to install and run a pre-built OpenBAS server with its dependencies. Note that this does not cover building from source,
+which you will find in the [Development section](/development/build_from_source) instead.
 
 ### Prepare the installation
 
@@ -216,22 +218,24 @@ OpenBAS will use the red user.
 
 You have to enable all the mandatory dependencies for the main application if you would like to play breach and attack
 simulation scenarios.
-You need at least Java 22, RabbitMQ, MinIO (for object storage) and PostgreSQL (database). See the [Dependencies section](overview.md#dependencies)
-for details on the recommended (and supported) versions of the dependencies.
 
 You may choose to use the dependencies from the provided compose file (see: [Using Docker](#using-docker)).
 If you elect doing so, make sure you disable the openbas server container first, and expose the dependencies on appropriate ports.
 You may refer to [the official Docker documentation](https://docs.docker.com/reference/compose-file/) to achieve this.
 
 Otherwise, you are responsible for providing the dependencies yourself by installing and running them.
+You need at least a Java Runtime, PostgreSQL (database), RabbitMQ (queue management), and MinIO (for object storage).
 
-The example below is for Ubuntu 24.04 LTS (not guaranteed to yield the recommended versions):
+!!! note "Supported dependency versions"
 
-```bash
-# Install Java 22, RabbitMQ and Postgres 16
-sudo apt install openjdk-22-jre rabbitmq-server postgresql-16 
-```
-Additionally, instructions to install MinIO for your platform can be found on the [MinIO website](https://min.io/docs). 
+    See the [Dependencies section](overview.md#dependencies) for details on the recommended (and supported) versions of the dependencies.
+
+If you choose to install the dependencies manually, please refer to their respective documentation:
+
+* Java: the [Java documentation portal](https://docs.oracle.com/en/java/)
+* PostgreSQL: the [PostgreSQL documentation portal](https://www.postgresql.org/docs/)
+* RabbitMQ: the [RabbitMQ documentation portal](https://www.rabbitmq.com/docs)
+* MinIO: the [MinIO website](https://min.io/docs). 
 
 #### Download the application files
 
@@ -260,7 +264,7 @@ application.properties  openbas-api.jar
 
     Note that the configuration keys relevant to the mandatory dependencies listed above must be set in the file or as environment variables.
 
-See the Configuration section for more details:
+See the relevant Configuration sections for more details:
 
 - [PostgreSQL](configuration.md#postgresql)
 - [RabbitMQ](configuration.md#rabbitmq)

--- a/docs/deployment/installation.md
+++ b/docs/deployment/installation.md
@@ -216,9 +216,10 @@ OpenBAS will use the red user.
 
 You have to install all the mandatory dependencies for the main application if you would like to play breach and attack
 simulation scenarios.
-You need at least Java 22, RabbitMQ, MinIO (for object storage) and PostgreSQL (16 and above).
+You need at least Java 22, RabbitMQ, MinIO (for object storage) and PostgreSQL (database). See the [Dependencies section](overview.md#dependencies)
+for details on the recommended (and supported) versions of the dependencies.
 
-The example below is for Ubuntu 24.04 LTS:
+The example below is for Ubuntu 24.04 LTS (not guaranteed to yield the recommended versions):
 
 ```bash
 # Install Java 22, RabbitMQ and Postgres 16

--- a/docs/deployment/installation.md
+++ b/docs/deployment/installation.md
@@ -214,10 +214,16 @@ OpenBAS will use the red user.
 
 #### Installation of dependencies
 
-You have to install all the mandatory dependencies for the main application if you would like to play breach and attack
+You have to enable all the mandatory dependencies for the main application if you would like to play breach and attack
 simulation scenarios.
 You need at least Java 22, RabbitMQ, MinIO (for object storage) and PostgreSQL (database). See the [Dependencies section](overview.md#dependencies)
 for details on the recommended (and supported) versions of the dependencies.
+
+You may choose to use the dependencies from the provided compose file (see: [Using Docker](#using-docker)).
+If you elect doing so, make sure you disable the openbas server container first, and expose the dependencies on appropriate ports.
+You may refer to [the official Docker documentation](https://docs.docker.com/reference/compose-file/) to achieve this.
+
+Otherwise, you are responsible for providing the dependencies yourself by installing and running them.
 
 The example below is for Ubuntu 24.04 LTS (not guaranteed to yield the recommended versions):
 
@@ -262,7 +268,9 @@ See the Configuration section for more details:
 
 #### Start the application
 
-Start the Application:
+Before you can start the application, ensure your dependencies are up and running, and healthy.
+
+Then start the application itself:
 
 ```bash
 java -jar openbas-api.jar

--- a/docs/deployment/installation.md
+++ b/docs/deployment/installation.md
@@ -81,16 +81,16 @@ MINIO_ROOT_USER=ChangeMeAccess
 MINIO_ROOT_PASSWORD=ChangeMeKey
 RABBITMQ_DEFAULT_USER=ChangeMe
 RABBITMQ_DEFAULT_PASS=ChangeMe
-SPRING_MAIL_HOST=smtp.changeme.com
+SPRING_MAIL_HOST=smtp.example.com
 SPRING_MAIL_PORT=465
-SPRING_MAIL_USERNAME=ChangeMe@domain.com
+SPRING_MAIL_USERNAME=ChangeMe@example.com
 SPRING_MAIL_PASSWORD=ChangeMe
 OPENBAS_MAIL_IMAP_ENABLED=true
-OPENBAS_MAIL_IMAP_HOST=imap.changeme.com
+OPENBAS_MAIL_IMAP_HOST=imap.example.com
 OPENBAS_MAIL_IMAP_PORT=993
-OPENBAS_ADMIN_EMAIL=ChangeMe@domain.com # Should be a valid email address
+OPENBAS_ADMIN_EMAIL=ChangeMe@example.com # must be a valid email address
 OPENBAS_ADMIN_PASSWORD=ChangeMe
-OPENBAS_ADMIN_TOKEN=ChangeMe # Should be a valid UUI
+OPENBAS_ADMIN_TOKEN=ChangeMe # must be a valid UUID
 COLLECTOR_MITRE_ATTACK_ID=3050d2a3-291d-44eb-8038-b4e7dd107436 # No need for change
 COLLECTOR_ATOMIC_RED_TEAM_ID=0f2a85c1-0a3b-4405-a79c-c65398ee4a76 # No need for change
 ```
@@ -214,12 +214,17 @@ OpenBAS will use the red user.
 
 #### Installation of dependencies
 
-You have to install all the needed dependencies for the main application if you would like to play breach and attack
-simulation scenarios. The example below is for Ubuntu:
+You have to install all the mandatory dependencies for the main application if you would like to play breach and attack
+simulation scenarios.
+You need at least Java 22, RabbitMQ, MinIO (for object storage) and PostgreSQL (16 and above).
+
+The example below is for Ubuntu 24.04 LTS:
 
 ```bash
-sudo apt install openjdk-22-jre
+# Install Java 22, RabbitMQ and Postgres 16
+sudo apt install openjdk-22-jre rabbitmq-server postgresql-16 
 ```
+Additionally, instructions to install MinIO for your platform can be found on the [MinIO website](https://min.io/docs). 
 
 #### Download the application files
 
@@ -235,14 +240,23 @@ tar xvfz openbas-release-{RELEASE_VERSION}.tar.gz
 
 #### Configure the application
 
-The main application has just one environment configuration file to change.
+You may change the `application.properties` file (located at the root of the extracted release archive)
+according to your needs; alternatively you may set the equivalent environment variables.
 
-```bash
-cd openbas
+```shell
+$ cd openbas
+$ ls
+application.properties  openbas-api.jar
 ```
 
-Change the *application.properties* file according to your configuration of PostgreSQL, RabbitMQ, Minio and to your
-platform.
+!!! note "Mandatory configuration"
+
+    Note that the configuration keys relevant to the mandatory dependencies listed above must be set in the file or as environment variables.
+
+See the Configuration section for more details:
+* [PostgreSQL](configuration.md#postgresql)
+* [RabbitMQ](configuration.md#rabbitmq)
+* [MinIO](configuration.md#s3-bucket)
 
 #### Start the application
 
@@ -273,7 +287,7 @@ java -jar openbas-api.jar
 
 ### Deploy behind a reverse proxy
 
-If you want to use OpenBAS behind a reverse proxy with a context path, like `https://domain.com/openbas`, please change
+If you want to use OpenBAS behind a reverse proxy with a context path, like `https://example.com/openbas`, please change
 the `base_path` static parameter.
 
 - `APP__BASE_PATH=/openbas`

--- a/docs/deployment/installation.md
+++ b/docs/deployment/installation.md
@@ -254,9 +254,10 @@ application.properties  openbas-api.jar
     Note that the configuration keys relevant to the mandatory dependencies listed above must be set in the file or as environment variables.
 
 See the Configuration section for more details:
-* [PostgreSQL](configuration.md#postgresql)
-* [RabbitMQ](configuration.md#rabbitmq)
-* [MinIO](configuration.md#s3-bucket)
+
+- [PostgreSQL](configuration.md#postgresql)
+- [RabbitMQ](configuration.md#rabbitmq)
+- [MinIO](configuration.md#s3-bucket)
 
 #### Start the application
 

--- a/docs/development/build_from_source.md
+++ b/docs/development/build_from_source.md
@@ -1,0 +1,5 @@
+# Building from source
+
+!!! tip "Under construction"
+
+    We are doing our best to complete this page. If you want to participate, don't hesitate to join the [Filigran Community on Slack](https://community.filigran.io) or submit your pull request on the [Github doc repository](https://github.com/OpenBAS-Platform/docs).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -180,6 +180,7 @@ nav:
     - Prerequisites:
       - Ubuntu: development/environment_ubuntu.md
       - Windows: development/environment_windows.md
+    - Build from source: development/build_from_source.md
     - Platform: development/platform.md
     - Injectors: development/injectors.md
     - REST API: development/api-usage.md


### PR DESCRIPTION
# Proposed changes

* Add emphasis on the mandatory aspect of configuring RabbitMQ, PostgreSQL and MinIO, with links to relevant docs sections.

Fix #89 