### PR TITLE
[Tanium] fix link to packages to the "live" (not permalink) url

### DIFF
--- a/docs/deployment/ecosystem/executors.md
+++ b/docs/deployment/ecosystem/executors.md
@@ -32,7 +32,7 @@ the [OpenBAS architecture](https://docs.openbas.io/latest/deployment/overview).
 ### Configure the Tanium Platform
 
 First of all, we are
-providing [2 Tanium packages](https://github.com/OpenBAS-Platform/openbas/blob/0978bf1e3c9ff92dfa8ac5e866ae7725cfb428ed/openbas-api/src/main/java/io/openbas/executors/tanium/openbas-tanium-packages.json)
+providing [2 Tanium packages](https://github.com/OpenBAS-Platform/openbas/blob/master/openbas-api/src/main/java/io/openbas/executors/tanium/openbas-tanium-packages.json)
 to be imported in the Tanium platform.
 
 ![Tanium Packages](../assets/tanium-packages.png)


### PR DESCRIPTION
Change the URL to the Tanium packages file to the "live" URL and not a permalink.

Why not a permalink? We will change the packages as our implant spawning strategy evolves and we want the link in the docs to always be accurate and give the latest available version without having to redeploy docs.

If we change the location of this file, the link should be amended then (or risk a 404).